### PR TITLE
Fixed link to page about ELF (01-compilation)

### DIFF
--- a/01-compilation.html
+++ b/01-compilation.html
@@ -328,7 +328,7 @@ There are no program headers in this file.
 		<li><em>Static</em> linking puts all necessary symbols in the resulting binary</li>
 		<li><em>Dynamic</em> linking calls the dynamic linker to load all the symbols lazily</li>
 	</ul>
-	<li><a href="https://www.cs.stevens.edu/~jschauma/631A/elf.html">https://www.cs.stevens.edu/~jschauma/631A/elf.html</a></li>
+	<li><a href="https://web.archive.org/web/20121126063759/http://www.acsu.buffalo.edu:80/~charngda/elf.html">https://web.archive.org/web/20121126063759/http://www.acsu.buffalo.edu:80/~charngda/elf.html</a></li>
 </ul>
 <pre>
 $ gcc test.o -static -o test


### PR DESCRIPTION
The current link to the page about the ELF is not working so I suggest changing the link to the original page from the Wayback Machine.